### PR TITLE
Add missing Capability enum values

### DIFF
--- a/src/Client/Models/Enums/Capability.cs
+++ b/src/Client/Models/Enums/Capability.cs
@@ -122,13 +122,23 @@ namespace Bytewizer.Backblaze.Models
         WriteBucketEncryption,
 
         /// <summary>
-        /// Permission to 
+        /// Permission to read bucket replication information.
         /// </summary>
         ReadBucketReplications,
 
         /// <summary>
-        /// Permission to 
+        /// Permission to write bucket replication information.
         /// </summary>
-        WriteBucketReplications
+        WriteBucketReplications,
+
+        /// <summary>
+        /// Permission to read the event notification rules for a bucket.
+        /// </summary>
+        ReadBucketNotifications,
+
+        /// <summary>
+        /// Permission to write event notification rule information for a bucket.
+        /// </summary>
+        WriteBucketNotifications,
     }
 }


### PR DESCRIPTION
When I tried to use this library today, I encountered errors trying to authenticate. After bashing my head against the wall trying to figure out what I was doing on for some time, I finally determined that the cause was actually nothing I was doing wrong. The JSON returned by Backblaze in response to successful authentication includes a list of Capability codes, and Backblaze have evidently added a couple of new ones, and the code blows up if it encounters Capability codes it doesn't recognize.

This PR adds new `Capability` enum values for the new codes returned by Backblaze:

* `ReadBucketNotifications`
* `WriteBucketNotifications`

I wonder also if there is some way to make the current structure of the code resilient to future changes of this type...