### PR TITLE
Resiliency to newly-added capabilities

### DIFF
--- a/Backblaze B2.sln
+++ b/Backblaze B2.sln
@@ -13,6 +13,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Backblaze.Client", "src\Cli
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Backblaze.Agent", "src\Agent\Backblaze.Agent.csproj", "{16C706DB-F611-4231-B061-F4B08DC8AAC1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Backblaze.Agent.Autofac", "src\Agent.Autofac\Backblaze.Agent.Autofac.csproj", "{FB6CB27C-5529-424D-8570-B69BA35C8FC1}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Backblaze.Tests.Unit", "test\Unit\Backblaze.Tests.Unit.csproj", "{6B57FB13-7D72-40D2-AE16-650A7B4990EC}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{9A70FFC5-6F45-48F6-8165-185D39517638}"
@@ -22,6 +24,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Backblaze.Tests.Integration", "test\Integration\Backblaze.Tests.Integration.csproj", "{A49A8C77-70CC-4ED7-83AE-ADAC6A36D036}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{6926CC64-2E92-4E58-BE15-6F9CA4EF16B0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -37,6 +41,10 @@ Global
 		{16C706DB-F611-4231-B061-F4B08DC8AAC1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{16C706DB-F611-4231-B061-F4B08DC8AAC1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{16C706DB-F611-4231-B061-F4B08DC8AAC1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FB6CB27C-5529-424D-8570-B69BA35C8FC1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FB6CB27C-5529-424D-8570-B69BA35C8FC1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FB6CB27C-5529-424D-8570-B69BA35C8FC1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FB6CB27C-5529-424D-8570-B69BA35C8FC1}.Release|Any CPU.Build.0 = Release|Any CPU
 		{6B57FB13-7D72-40D2-AE16-650A7B4990EC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6B57FB13-7D72-40D2-AE16-650A7B4990EC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6B57FB13-7D72-40D2-AE16-650A7B4990EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -51,6 +59,7 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{9A70FFC5-6F45-48F6-8165-185D39517638} = {B89C1FC0-7893-4D07-8D41-9E22A8D51D48}
+		{FB6CB27C-5529-424D-8570-B69BA35C8FC1} = {6926CC64-2E92-4E58-BE15-6F9CA4EF16B0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DAA59421-E9E6-427B-942E-F64F5F490239}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Backblaze Agent for .NET Core
 
-[![NuGet Version](https://img.shields.io/nuget/vpre/Backblaze.Agent.svg?style=flat-square)](https://www.nuget.org/packages/Backblaze.Agent)
-[![NuGet Downloads](https://img.shields.io/nuget/dt/Backblaze.Agent.svg?style=flat-square)](https://www.nuget.org/packages/Backblaze.Agent)
+[![NuGet Version](https://img.shields.io/nuget/vpre/DQD.Backblaze.Agent.svg?style=flat-square)](https://www.nuget.org/packages/DQD.Backblaze.Agent)
+[![NuGet Downloads](https://img.shields.io/nuget/dt/DQD.Backblaze.Agent.svg?style=flat-square)](https://www.nuget.org/packages/DQD.Backblaze.Agent)
 
 The Backblaze Agent (client) for .NET Core is an implementation of the [Backblaze B2 Cloud Storage API](https://www.backblaze.com/b2/cloud-storage.html). Backblaze B2 Cloud Storage provides the cheapest cloud storage available on the internet. Backblaze B2 Cloud Storage is ¼ of the price of other storage providers. Give it a try as the first 10 GB of storage is free.
 
@@ -14,21 +14,25 @@ The Backblaze Agent (client) for .NET Core is an implementation of the [Backblaz
  - Large file support with low memory allocation and IProgress status.
  - Native support of task based programming model (async/await).
 
-For feature requests and bug reports, please [open an issue on GitHub](https://github.com/microcompiler/backblaze/issues/new).
+For feature requests and bug reports, please [open an issue on GitHub](https://github.com/logiclrd/DQD.Backblaze/issues/new).
+
+## Divergence
+
+This library was originally being developed as [microcompiler.backblaze](https://github.com/microcompiler/backblaze), but that development effort appears to have been abandoned and the team members seem to be unreachable. If they resume activity in the future and merge my changes upstream, then I intend to shutter this fork. Until then, this fork allows me to proceed with my development efforts with another project that consumes this library.
 
 ## Installation via .NET CLI
 
-To install Backblaze.Agent run the following command:
+To install DQD.Backblaze.Agent run the following command:
 
 ```bash
-> dotnet add package Backblaze.Agent
+> dotnet add package DQD.Backblaze.Agent
 ```
 
 ## Getting Started
 
 *Work in Progress!* Whilst we encourage users to play with the samples and test programs, this project has not yet reached a stable state.
 
-You will need an **key_id** and an **application_key** to configure Backblaze Agent. You can obtain these from the [Backblaze B2 Cloud Storage](https://www.backblaze.com/b2/cloud-storage.html) portal. See the [Sample Project](https://github.com/microcompiler/backblaze/tree/master/samples ) for an example of how to use this packages.
+You will need an **key_id** and an **application_key** to configure Backblaze Agent. You can obtain these from the [Backblaze B2 Cloud Storage](https://www.backblaze.com/b2/cloud-storage.html) portal. See the [Sample Project](https://github.com/logiclrd/DQD.Backblaze/tree/main/samples ) for an example of how to use this packages.
 
 ### Adding Backblaze Agent to Services
 
@@ -212,7 +216,7 @@ services.AddBackblazeAgent(options =>
 });
 ```
 
-The following table describes the [Agent Options](https://github.com/microcompiler/backblaze/blob/master/src/Client/Client/IClientOptions.cs) available:
+The following table describes the [Agent Options](https://github.com/logiclrd/DQD.Backblaze/blob/main/src/Client/Client/IClientOptions.cs) available:
 
 | Option Name | Default | Description |
 | ----------- | ------- | ----------- |
@@ -252,7 +256,7 @@ The following test mode options are available to verify that your code correctly
 
 ## Integration Tests
 
-You will need an **key_id** and an **application_key** to configure Backblaze Test Agent [settings.json](https://github.com/microcompiler/backblaze/blob/master/test/Integration/settings.json) file.
+You will need an **key_id** and an **application_key** to configure Backblaze Test Agent [settings.json](https://github.com/logiclrd/DQD.Backblaze/blob/main/test/Integration/settings.json) file.
 
 ## Disclaimer
 
@@ -260,9 +264,9 @@ All source, documentation, instructions and products of this project are provide
 
 ## Branches
 
-**master** - This is the branch containing the latest release - no contributions should be made directly to this branch.
+**main** - This is the branch containing the latest release - no contributions should be made directly to this branch.
 
-**develop** - This is the development branch to which contributions should be proposed by contributors as pull requests. This development branch will periodically be merged to the master branch, and be released to [NuGet Gallery](https://www.nuget.org).
+**develop** - This is the development branch to which contributions should be proposed by contributors as pull requests. This development branch will periodically be merged to the main branch, and be released to [NuGet Gallery](https://www.nuget.org).
 
 ## Contributions
 

--- a/src/Agent.Autofac/Backblaze.Agent.Autofac.csproj
+++ b/src/Agent.Autofac/Backblaze.Agent.Autofac.csproj
@@ -1,0 +1,68 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PackageId>DQD.Backblaze.Agent.Autofac</PackageId>
+    <Authors>logiclrd</Authors>
+    <Product>Backblaze B2 Cloud Storage</Product>
+    <LangVersion>7.1</LangVersion>
+    <RootNamespace>Bytewizer.Backblaze</RootNamespace>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <Version Condition=" '$(Version)' == '' and '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</Version>
+    <Version Condition=" '$(Version)' == '' ">$(VersionPrefix)</Version>
+    <BuildNumber Condition=" '$(BuildNumber)' == '' ">0</BuildNumber>
+    <AssemblyVersion>$(VersionPrefix).$(BuildNumber)</AssemblyVersion>
+    <AssemblyName>DQD.Backblaze.Agent.Autofac</AssemblyName>
+    <FileVersion>$(VersionPrefix).$(BuildNumber)</FileVersion>
+    <PackageId>$(AssemblyName)</PackageId>
+    <Description>Autofac integration for Backblaze.Client.</Description>
+    <Copyright>(c) 0000 Delta Q Development.  All rights reserved.</Copyright>
+    <PackageProjectUrl>https://github.com/logiclrd/DQD.Backblaze</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/logiclrd/DQD.Backblaze</RepositoryUrl>
+    <PackageTags>backblaze, b2, cloud-storage, api, csharp, storage-pod</PackageTags>
+    <RepositoryType></RepositoryType>
+    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+    <PackageIcon>logo.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <NoWarn>NU5105</NoWarn>
+  </PropertyGroup>
+
+  <!-- Github Properties -->
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DocumentationFile />
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Autofac" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\LICENSE.md" Link="LICENSE.md">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\images\logo.png">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Client\Backblaze.Client.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Agent.Autofac/ContainerBuilderExtensions.cs
+++ b/src/Agent.Autofac/ContainerBuilderExtensions.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Net.Http;
+
+using Autofac;
+
+using Bytewizer.Backblaze.Client;
+using Bytewizer.Backblaze.Handlers;
+
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace DQD.Backblaze.Agent.Autofac
+{
+    /// <summary>
+    /// Extension methods for setting up the agent in an Autofac <see cref="ContainerBuilder" />.
+    /// </summary>
+    public static class ContainerBuilderExtensions
+    {
+        /// <summary>
+        /// Adds the repository agent services to the collection.
+        /// </summary>
+        /// <param name="services">The service collection.</param>
+        /// <param name="setupBuilder">Delegate to define the configuration.</param>
+        public static ContainerBuilder AddBackblazeAgent(this ContainerBuilder services, Action<IClientOptions> setupBuilder)
+        {
+            if (services == null)
+                throw new ArgumentNullException(nameof(services));
+
+            if (setupBuilder == null)
+                throw new ArgumentNullException(nameof(setupBuilder));
+
+            var options = new ClientOptions();
+            setupBuilder(options);
+
+            return AddBackblazeAgent(services, options);
+        }
+
+        /// <summary>
+        /// Adds the Backblaze client agent services to the collection.
+        /// </summary>
+        /// <param name="services">The service collection.</param>
+        /// <param name="options">The agent options.</param>
+        public static ContainerBuilder AddBackblazeAgent(this ContainerBuilder services, IClientOptions options)
+        {
+            if (services == null)
+                throw new ArgumentNullException(nameof(services));
+
+            if (options == null)
+                throw new ArgumentNullException(nameof(options));
+
+            options.Validate();
+
+            services.RegisterInstance(options).AsImplementedInterfaces();
+
+            services.RegisterType<UserAgentHandler>();
+            services.RegisterType<HttpErrorHandler>();
+
+            services.RegisterType<StorageService>().SingleInstance();
+
+            services.RegisterType<HttpClient>();
+
+            var memoryCacheOptions = new MemoryCacheOptions();
+
+            services.RegisterInstance(Options.Create(memoryCacheOptions)).AsImplementedInterfaces();
+
+            services.RegisterInstance(LoggerFactory.Create(_ => { })).AsImplementedInterfaces().IfNotRegistered(typeof(ILoggerFactory));
+            services.RegisterType<MemoryCache>().AsImplementedInterfaces();
+
+            services.RegisterType<BackblazeClient>().As<IStorageClient>();
+
+            return services;
+        }
+    }
+}

--- a/src/Agent/Backblaze.Agent.csproj
+++ b/src/Agent/Backblaze.Agent.csproj
@@ -6,7 +6,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <PackageId>Backblaze.Agent</PackageId>
+    <PackageId>DQD.Backblaze.Agent</PackageId>
     <Authors>Microcompiler</Authors>
     <Company>Bytewizer Inc.</Company>
     <Product>Backblaze B2 Cloud Storage</Product>
@@ -17,17 +17,18 @@
     <Version Condition=" '$(Version)' == '' ">$(VersionPrefix)</Version>
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">0</BuildNumber>
     <AssemblyVersion>$(VersionPrefix).$(BuildNumber)</AssemblyVersion>
-    <AssemblyName>Backblaze.Agent</AssemblyName>
+    <AssemblyName>DQD.Backblaze.Agent</AssemblyName>
     <FileVersion>$(VersionPrefix).$(BuildNumber)</FileVersion>
     <PackageId>$(AssemblyName)</PackageId>
     <Description>Backblaze.Agent is a high-performance .NET Core implementation of the Backblaze B2 Cloud Storage supporting dependency injection, caching and logging.</Description>
     <Copyright>(c) 0000 Bytewizer.  All rights reserved.</Copyright>
-    <PackageProjectUrl>https://github.com/microcompiler/backblaze</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/microcompiler/backblaze</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/logiclrd/DQD.Backblaze</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/logiclrd/DQD.Backblaze</RepositoryUrl>
     <PackageTags>backblaze, b2, cloud-storage, api, csharp, storage-pod</PackageTags>
     <RepositoryType></RepositoryType>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <PackageIcon>logo.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <NoWarn>NU5105</NoWarn>
   </PropertyGroup>
 
@@ -49,6 +50,7 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Client/Backblaze.Client.csproj
+++ b/src/Client/Backblaze.Client.csproj
@@ -6,7 +6,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <PackageId>Backblaze.Client</PackageId>
+    <PackageId>DQD.Backblaze.Client</PackageId>
     <Authors>Microcompiler</Authors>
     <Company>Bytewizer Inc.</Company>
     <Product>Backblaze B2 Cloud Storage</Product>
@@ -17,20 +17,21 @@
     <Version Condition=" '$(Version)' == '' ">$(VersionPrefix)</Version>
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">0</BuildNumber>
     <AssemblyVersion>$(VersionPrefix).$(BuildNumber)</AssemblyVersion>
-    <AssemblyName>Backblaze.Client</AssemblyName>
+    <AssemblyName>DQD.Backblaze.Client</AssemblyName>
     <FileVersion>$(VersionPrefix).$(BuildNumber)</FileVersion>
     <PackageId>$(AssemblyName)</PackageId>
     <Description>Backblaze.Client is a high-performance .NET Core implementation of the Backblaze B2 Cloud Storage.</Description>
     <Copyright>(c) 0000 Bytewizer.  All rights reserved.</Copyright>
-    <PackageProjectUrl>https://github.com/microcompiler/backblaze</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/microcompiler/backblaze</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/logiclrd/DQD.Backblaze</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/logiclrd/DQD.Backblaze</RepositoryUrl>
     <PackageTags>backblaze, b2, cloud-storage, api, csharp, storage-pod</PackageTags>
     <RepositoryType></RepositoryType>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <PackageIcon>logo.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <NoWarn>NU5105</NoWarn>
   </PropertyGroup>
-  
+
   <!-- Github Properties -->
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
@@ -59,6 +60,7 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Client/Backblaze.Client.csproj
+++ b/src/Client/Backblaze.Client.csproj
@@ -10,7 +10,7 @@
     <Authors>Microcompiler</Authors>
     <Company>Bytewizer Inc.</Company>
     <Product>Backblaze B2 Cloud Storage</Product>
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <RootNamespace>Bytewizer.Backblaze</RootNamespace>
     <VersionPrefix>1.0.0</VersionPrefix>
     <Version Condition=" '$(Version)' == '' and '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</Version>

--- a/src/Client/Client/ApiRest.Endpoints.cs
+++ b/src/Client/Client/ApiRest.Endpoints.cs
@@ -329,8 +329,13 @@ namespace Bytewizer.Backblaze.Client
             if (request == null)
                 throw new ArgumentNullException(nameof(request));
 
+            string fileName = request.FileName;
+
+            if (fileName.StartsWith("/"))
+                fileName = fileName.Substring(1);
+
             var httpRequest = new HttpRequestMessage
-                (HttpMethod.Get, $"{AccountInfo.DownloadUrl}file/{request.BucketName}/{request.FileName}");
+                (HttpMethod.Get, $"{AccountInfo.DownloadUrl}file/{request.BucketName}/{fileName.ToUrlEncode()}");
 
             httpRequest.Headers.SetAuthorization(request.AuthorizationToken, AuthToken.Authorization);
             httpRequest.Headers.SetRange(request.Range);

--- a/src/Client/Client/Storage/IStorageFiles.cs
+++ b/src/Client/Client/Storage/IStorageFiles.cs
@@ -186,7 +186,25 @@ namespace Bytewizer.Backblaze.Client
         Task<IApiResults<UploadFileResponse>> UploadAsync(string bucketId, string fileName, string localPath, IProgress<ICopyProgress> progress, CancellationToken cancel);
 
         /// <summary>
-        /// Downloads a file by bucket and file name from Backblaze B2 Cloud Storage. 
+        /// Uploads a file by bucket id and filename to Backblaze B2 Cloud Storage, with the file content and attributes supplied explicitly by the caller.
+        /// </summary>
+        /// <param name="bucketId">The bucket id you want to upload to.</param>
+        /// <param name="fileName">The name of the file to upload.</param>
+        /// <param name="content">A stream from which the content to upload for the file can be read.</param>
+        /// <param name="lastModified">The DateTime to register as the file's last-modified date/time.</param>
+        /// <param name="isReadOnly">True if the file should be marked read-only.</param>
+        /// <param name="isHidden">True if the file should be marked hidden.</param>
+        /// <param name="isArchive">True if the file should be marked for archiving.</param>
+        /// <param name="isCompressed">True if the file should be marked compressed.</param>
+        /// <param name="progress">A progress action which fires every time the write buffer is cycled.</param>
+        /// <param name="cancel">The cancellation token to cancel operation.</param>
+        /// <returns></returns>
+        Task<IApiResults<UploadFileResponse>> UploadAsync
+            (string bucketId, string fileName, Stream content, DateTime lastModified, bool isReadOnly, bool isHidden, bool isArchive, bool isCompressed,
+            IProgress<ICopyProgress> progress, CancellationToken cancel);
+
+        /// <summary>
+        /// Downloads a file by bucket and file name from Backblaze B2 Cloud Storage.
         /// </summary>
         /// <param name="bucketName">The name of the bucket to download from.</param>
         /// <param name="fileName">The name of the file to download.</param>

--- a/src/Client/Client/Utility/SpeedCalculator.cs
+++ b/src/Client/Client/Utility/SpeedCalculator.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+
+namespace Bytewizer.Backblaze.Utility
+{
+    /// <summary>
+    /// Calculates transfer speed as a rolling average. Every time the position changes,
+    /// the consumer notifies us and a timestamped sample is logged.
+    /// </summary>
+    public class SpeedCalculator
+    {
+        List<Sample> _samples = new List<Sample>();
+
+        struct Sample
+        {
+            public long Position;
+            public DateTime DateTimeUTC;
+        }
+
+        /// <summary>
+        /// The length in seconds of the window across which speed is averaged.
+        /// </summary>
+        public const int WindowSeconds = 10;
+
+        /// <summary>
+        /// Adds a position sample to the set. It is automatically timestamped. Samples
+        /// should be monotonically increasing. If, for whatever reason, they are not,
+        /// previously-added samples that are later in the file are discarded so that
+        /// the set remains strictly increasing.
+        /// </summary>
+        /// <param name="position">The updated position of the operation.</param>
+        public void AddSample(long position)
+        {
+            var sample = new Sample();
+
+            sample.Position = position;
+            sample.DateTimeUTC = DateTime.UtcNow;
+
+            // If we have walked backward for whatever reason, discard any samples past this
+            // point so that we maintain the invariant of the sample set increasing position
+            // monotonically.
+            while ((_samples.Count > 0) && (_samples[_samples.Count - 1].Position > position))
+                _samples.RemoveAt(_samples.Count - 1);
+
+            _samples.Add(sample);
+        }
+
+        /// <summary>
+        /// Calculates the current speed based on samples previously added by calls to
+        /// <see cref="AddSample" />. The value of this function will change over time,
+        /// even with no changes to the state of the <see cref="SpeedCalculator" />
+        /// instance, because the value is relative to the current date/time, and the
+        /// samples with which the calculation is being made are timestamped.
+        /// </summary>
+        /// <returns>The average number of bytes per second being processed.</returns>
+        public long CalculateBytesPerSecond()
+        {
+            var cutoff = DateTime.UtcNow.AddSeconds(-WindowSeconds);
+
+            // Discard any samples that are outside of the averaging window. We will never
+            // need them again.
+            while ((_samples.Count > 0) && (_samples[0].DateTimeUTC < cutoff))
+                _samples.RemoveAt(0);
+
+            if (_samples.Count < 2)
+                return 0;
+
+            var firstSample = _samples[0];
+            var lastSample = _samples[_samples.Count - 1];
+
+            long bytes = lastSample.Position - firstSample.Position;
+            double seconds = (lastSample.DateTimeUTC - firstSample.DateTimeUTC).TotalSeconds;
+
+            // If we don't have a meaningful span of time, clamp it. The number wouldn't
+            // be terribly meaningful anyway.
+            if (seconds < 0.01)
+                seconds = 0.01;
+
+            return (long)Math.Round(bytes / seconds);
+        }
+    }
+}

--- a/src/Client/Models/Enums/Capability.cs
+++ b/src/Client/Models/Enums/Capability.cs
@@ -122,13 +122,23 @@ namespace Bytewizer.Backblaze.Models
         WriteBucketEncryption,
 
         /// <summary>
-        /// Permission to 
+        /// Permission to read bucket replication information.
         /// </summary>
         ReadBucketReplications,
 
         /// <summary>
-        /// Permission to 
+        /// Permission to write bucket replication information.
         /// </summary>
-        WriteBucketReplications
+        WriteBucketReplications,
+
+        /// <summary>
+        /// Permission to read the event notification rules for a bucket.
+        /// </summary>
+        ReadBucketNotifications,
+
+        /// <summary>
+        /// Permission to write event notification rule information for a bucket.
+        /// </summary>
+        WriteBucketNotifications,
     }
 }


### PR DESCRIPTION
Backblaze periodically adds new "capabilities" to the B2 API. The current strategy for parsing the models associated with successful logins requires all capabilities to be recognized. This breaks the library every time it happens. This PR aims to provide resiliency to this situation, by making the raw parsing of the "Allowed" structure in new type `AllowedRaw` just use a list of strings for the capabilities, and then later sorting them into known and unknown capabilities for the actual `Allowed` object returned by the `Connect` call.

I have not yet tested this code.

@mutiadavid 