### PR TITLE
 Apply URL encoding to the filename injected into the URL in DownloadFileByNameAsync

### DIFF
--- a/src/Client/Client/ApiRest.Endpoints.cs
+++ b/src/Client/Client/ApiRest.Endpoints.cs
@@ -329,8 +329,13 @@ namespace Bytewizer.Backblaze.Client
             if (request == null)
                 throw new ArgumentNullException(nameof(request));
 
+            string fileName = request.FileName;
+
+            if (fileName.StartsWith("/"))
+                fileName = fileName.Substring(1);
+
             var httpRequest = new HttpRequestMessage
-                (HttpMethod.Get, $"{AccountInfo.DownloadUrl}file/{request.BucketName}/{request.FileName}");
+                (HttpMethod.Get, $"{AccountInfo.DownloadUrl}file/{request.BucketName}/{fileName.ToUrlEncode()}");
 
             httpRequest.Headers.SetAuthorization(request.AuthorizationToken, AuthToken.Authorization);
             httpRequest.Headers.SetRange(request.Range);


### PR DESCRIPTION
The `b2_download_file_by_name` endpoint is problematic, because it takes the filename in the request URI, compared to all other requests involving a filename which take it as a member of a POST request body, and Backblaze's B2 servers include additional processing on the URI. This means that there are completely legitimate filenames that get rejected by the `b2_download_file_by_name` endpoint. (The workaround is to convert the filename to a `FileId` and then use `b2_download_file_by_id`.)

There are some cases, though, where a request fails simply because of the encoding of the filename. The `b2_download_file_by_name` endpoint is expecting the  filename to be encoded for use in a URL, and the library implementation does not do that. Certain characters need to be `%`-encoded. In addition, if the filename begins with a `/` character, it must not be doubled up in the request URI following the bucket name.

For reference, in my consuming codebase, the list of characters that need to be avoided, for which the work-around needs to be used because `DownloadFileByNameAsync` will fail spuriously, seems to be:
```
		static char[] B2ProblematicFileNameCharacters = { ',', '[', ']', '&', '_' };
```
It is possible that there are others; these are the ones I have encountered in practice in my usage.

(I have reported this bug to Backblaze, that there are filenames that work everywhere else in the API but not in the `GET`-based download-by-name, but they don't seem particularly worried and I doubt they are planning to fix it.)