### PR TITLE
Resiliency to newly-added capabilities

### DIFF
--- a/src/Client/Backblaze.Client.csproj
+++ b/src/Client/Backblaze.Client.csproj
@@ -10,7 +10,7 @@
     <Authors>Microcompiler</Authors>
     <Company>Bytewizer Inc.</Company>
     <Product>Backblaze B2 Cloud Storage</Product>
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <RootNamespace>Bytewizer.Backblaze</RootNamespace>
     <VersionPrefix>1.1.0</VersionPrefix>
     <Version Condition=" '$(Version)' == '' and '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</Version>

--- a/src/Client/Client/ApiRest.Endpoints.cs
+++ b/src/Client/Client/ApiRest.Endpoints.cs
@@ -13,6 +13,8 @@ using Microsoft.Extensions.Logging;
 using Bytewizer.Backblaze.Models;
 using Bytewizer.Backblaze.Extensions;
 
+using Bytewizer.Backblaze.Client.Internal;
+
 namespace Bytewizer.Backblaze.Client
 {
     public abstract partial class ApiRest : DisposableObject
@@ -47,7 +49,9 @@ namespace Bytewizer.Backblaze.Client
             using (var results = await _policy.InvokeClient.ExecuteAsync(async () =>
                 { return await _httpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false); }))
             {
-                return await HandleResponseAsync<AuthorizeAccountResponse>(results).ConfigureAwait(false);
+                var rawResult = await HandleResponseAsync<AuthorizeAccountResponseRaw>(results).ConfigureAwait(false);
+
+                return new ApiResults<AuthorizeAccountResponse>(rawResult.HttpResponse, rawResult.Response.ToAuthorizedAccountResponse());
             }
 
         }

--- a/src/Client/Client/Internal/AllowedRaw.cs
+++ b/src/Client/Client/Internal/AllowedRaw.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Newtonsoft.Json;
+
+using Bytewizer.Backblaze.Models;
+
+namespace Bytewizer.Backblaze.Client.Internal
+{
+    /// <summary>
+    /// Represents information related to an allowed authorization.
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay, nq}")]
+    internal class AllowedRaw
+    {
+        /// <summary>
+        /// Gets or sets a list of <see cref="Capability"/> allowed.
+        /// </summary>
+        [JsonProperty(Required = Required.Always)]
+        public List<string> Capabilities { get; set; }
+
+        /// <summary>
+        /// Gets or sets restricted access only to this bucket id.
+        /// </summary>
+        public string BucketId { get; set; }
+
+        /// <summary>
+        /// When bucket id is set and it is a valid bucket that has not been deleted this field is set to the name of the
+        /// bucket. It's possible that bucket id is set to a bucket that no longer exists in which case this field will be
+        /// <c>null</c>. It's also null when bucket id is <c>null</c>.
+        /// </summary>
+        public string BucketName { get; set; }
+
+        /// <summary>
+        /// Gets or sets restricted access to files whose names start with the prefix.
+        /// </summary>
+        public string NamePrefix { get; set; }
+
+        /// <summary>
+        /// Debugger display for this object.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private string DebuggerDisplay
+        {
+            get { return $"{{{nameof(Capabilities)}: {string.Join(", ", Capabilities)}, {nameof(NamePrefix)}: {NamePrefix}}}"; }
+        }
+
+        /// <summary>
+        /// Translates this <see cref="AllowedRaw"/> instance to an instance of <see cref="Allowed"/>,
+        /// parsing capabilities into the <see cref="Allowed.Capabilities"/> and
+        /// <see cref="Allowed.UnknownCapabilities"/> properties.
+        /// </summary>
+        /// <returns>An instance of <see cref="Allowed"/>.</returns>
+        public Allowed ParseCapabilities()
+        {
+            Allowed parsed = new Allowed();
+
+            parsed.BucketId = this.BucketId;
+            parsed.BucketName = this.BucketName;
+            parsed.NamePrefix = this.NamePrefix;
+
+            foreach (string capabilityName in this.Capabilities)
+            {
+                if (Enum.TryParse<Capability>(capabilityName, out var parsedCapability))
+                {
+                    parsed.Capabilities.Add(parsedCapability);
+                }
+                else
+                {
+                    parsed.UnknownCapabilities ??= new List<string>();
+                    parsed.UnknownCapabilities.Add(capabilityName);
+                }
+            }
+
+            return parsed;
+        }
+    }
+}

--- a/src/Client/Client/Internal/AllowedRaw.cs
+++ b/src/Client/Client/Internal/AllowedRaw.cs
@@ -60,17 +60,15 @@ namespace Bytewizer.Backblaze.Client.Internal
             parsed.BucketName = this.BucketName;
             parsed.NamePrefix = this.NamePrefix;
 
+            parsed.Capabilities = new Capabilities();
+            parsed.UnknownCapabilities = new List<string>();
+
             foreach (string capabilityName in this.Capabilities)
             {
                 if (Enum.TryParse<Capability>(capabilityName, out var parsedCapability))
-                {
                     parsed.Capabilities.Add(parsedCapability);
-                }
                 else
-                {
-                    parsed.UnknownCapabilities ??= new List<string>();
                     parsed.UnknownCapabilities.Add(capabilityName);
-                }
             }
 
             return parsed;

--- a/src/Client/Client/Internal/AuthorizeAccountResponseRaw.cs
+++ b/src/Client/Client/Internal/AuthorizeAccountResponseRaw.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Diagnostics;
+
+using Newtonsoft.Json;
+
+using Bytewizer.Backblaze.Models;
+
+namespace Bytewizer.Backblaze.Client.Internal
+{
+    /// <summary>
+    /// Contains the results of authorize account request operation.
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay, nq}")]
+    internal class AuthorizeAccountResponseRaw : IResponse
+    {
+        /// <summary>
+        /// The identifier for the account.
+        /// </summary>
+        [JsonProperty(Required = Required.Always)]
+        public string AccountId { get; internal set; }
+
+        /// <summary>
+        /// An authorization token to use with all calls other than authorize account that need an authorization header.
+        /// This authorization token is valid for at most 24 hours.
+        /// </summary>
+        [JsonProperty(Required = Required.Always)]
+        public string AuthorizationToken { get; internal set; }
+
+        /// <summary>
+        /// The capabilities of this auth token and any restrictions on using it.
+        /// </summary>
+        [JsonProperty(Required = Required.Always)]
+        public AllowedRaw Allowed { get; internal set; }
+
+        /// <summary>
+        /// The base url to use for all API calls except for uploading and downloading files.
+        /// </summary>
+        [JsonProperty(Required = Required.Always)]
+        public Uri ApiUrl { get; internal set; }
+
+        /// <summary>
+        /// The base url to use for downloading files.
+        /// </summary>
+        [JsonProperty(Required = Required.Always)]
+        public Uri DownloadUrl { get; internal set; }
+
+        /// <summary>
+        /// The recommended size for each part of a large file. We recommend using this part size for optimal upload performance.
+        /// </summary>
+        [JsonProperty(Required = Required.Always)]
+        public long RecommendedPartSize { get; internal set; }
+
+        /// <summary>
+        /// The smallest possible size of a part of a large file (except the last one). This is smaller than the <see cref="RecommendedPartSize"/>.
+        /// If you use it you may find that it takes longer overall to upload a large file.
+        /// </summary>
+        [JsonProperty(Required = Required.Always)]
+        public long AbsoluteMinimumPartSize { get; internal set; }
+
+        /// <summary>
+        /// OBSOLETE: This field will always have the same value as <see cref="RecommendedPartSize"/>.
+        /// </summary>
+        [Obsolete("This field will always have the same value as 'RecommendedPartSize'.")]
+        public long MinimumPartSize { get; internal set; }
+
+        ///	<summary>
+        ///	Debugger display for this object.
+        ///	</summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private string DebuggerDisplay
+        {
+            get { return $"{{{nameof(AccountId)}: {AccountId}, {nameof(AuthorizationToken)}: {AuthorizationToken}}}"; }
+        }
+
+        internal AuthorizeAccountResponse ToAuthorizedAccountResponse()
+        {
+            var response = new AuthorizeAccountResponse();
+
+            response.AccountId = this.AccountId;
+            response.AuthorizationToken = this.AuthorizationToken;
+            response.Allowed = this.Allowed.ParseCapabilities();
+            response.ApiUrl = this.ApiUrl;
+            response.DownloadUrl = this.DownloadUrl;
+            response.RecommendedPartSize = this.RecommendedPartSize;
+            response.AbsoluteMinimumPartSize = this.AbsoluteMinimumPartSize;
+
+            #pragma warning disable 618
+            response.MinimumPartSize = this.MinimumPartSize;
+            #pragma warning restore 618
+
+            return response;
+        }
+    }
+}

--- a/src/Client/Models/Allowed.cs
+++ b/src/Client/Models/Allowed.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System.Collections.Generic;
+using System.Diagnostics;
 
 using Newtonsoft.Json;
 
@@ -15,6 +16,11 @@ namespace Bytewizer.Backblaze.Models
         /// </summary>
         [JsonProperty(Required = Required.Always)]
         public Capabilities Capabilities { get; set; }
+
+        /// <summary>
+        /// Gets or sets a list of capabilities that couldn't be parsed into <see cref="Capability"/> values.
+        /// </summary>
+        public List<string> UnknownCapabilities { get; set; }
 
         /// <summary>
         /// Gets or sets restricted access only to this bucket id.
@@ -39,7 +45,17 @@ namespace Bytewizer.Backblaze.Models
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private string DebuggerDisplay
         {
-            get { return $"{{{nameof(Capabilities)}: {string.Join(", ", Capabilities)}, {nameof(NamePrefix)}: {NamePrefix}}}"; }
+            get
+            {
+                string unknownCapabilitiesString = "";
+
+                if ((this.UnknownCapabilities != null) && (this.UnknownCapabilities.Count > 0))
+                {
+                    unknownCapabilitiesString = " (+ " + string.Join(", ", UnknownCapabilities) + ")";
+                }
+
+                return $"{{{nameof(Capabilities)}: {string.Join(", ", Capabilities)}{unknownCapabilitiesString}, {nameof(NamePrefix)}: {NamePrefix}}}";
+            }
         }
     }
 }

--- a/src/Client/Properties/AssemblyInfo.cs
+++ b/src/Client/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Backblaze.Tests.Unit")]

--- a/test/Unit/ApiClientFixture.cs
+++ b/test/Unit/ApiClientFixture.cs
@@ -20,138 +20,141 @@ using FluentAssertions;
 
 using Bytewizer.Backblaze.Models;
 
-public class ApiClientFixture
+namespace Backblaze.Tests.Unit
 {
-    [Fact]
-    public async Task AuthorizeAccountAync_should_parse_capabilities()
+    public class ApiClientFixture
     {
-        // Arrange
-        var faker = new Faker();
-
-        var dummyKeyId = faker.Random.Hash();
-        var dummyApplicationKey = faker.Random.Hash();
-        var dummyAccountId = faker.Random.Hash();
-        var dummyAuthorizationToken = faker.Random.Hash();
-        var dummyApiUrl = new Uri(faker.Internet.Url());
-        var dummyDownloadUrl = new Uri(faker.Internet.Url());
-        var dummyCapabilities = faker.PickRandom(Enum.GetValues(typeof(Capability)).OfType<Capability>(), 5).ToList();
-        var dummyCapabilityStrings = dummyCapabilities.Select(c => c.ToString()).ToList();
-
-        var mockHttpClient = new HttpClient();
-
-        var clientOptions = new ClientOptions();
-
-        clientOptions.RequestMaxParallel = 1;
-        clientOptions.DownloadMaxParallel = 1;
-        clientOptions.UploadMaxParallel = 1;
-        clientOptions.TestMode = "";
-
-        var mockLogger = Substitute.For<ILogger<ApiRest>>();
-
-        var mockMemoryCache = Substitute.For<IMemoryCache>();
-
-        using (var testServer = new TestServer())
+        [Fact]
+        public async Task AuthorizeAccountAync_should_parse_capabilities()
         {
-            testServer
-                .When("/b2_authorize_account")
-                .Then(
-                    new AuthorizeAccountResponseRaw()
-                    {
-                        AccountId = dummyAccountId,
-                        AuthorizationToken = dummyAuthorizationToken,
-                        ApiUrl = dummyApiUrl,
-                        DownloadUrl = dummyDownloadUrl,
-                        Allowed =
-                            new AllowedRaw()
-                            {
-                                Capabilities = dummyCapabilityStrings
-                            }
-                    });
+            // Arrange
+            var faker = new Faker();
 
-            var sut = new ApiClient(mockHttpClient, clientOptions, mockLogger, mockMemoryCache);
+            var dummyKeyId = faker.Random.Hash();
+            var dummyApplicationKey = faker.Random.Hash();
+            var dummyAccountId = faker.Random.Hash();
+            var dummyAuthorizationToken = faker.Random.Hash();
+            var dummyApiUrl = new Uri(faker.Internet.Url());
+            var dummyDownloadUrl = new Uri(faker.Internet.Url());
+            var dummyCapabilities = faker.PickRandom(Enum.GetValues(typeof(Capability)).OfType<Capability>(), 5).ToList();
+            var dummyCapabilityStrings = dummyCapabilities.Select(c => c.ToString()).ToList();
 
-            sut.AccountInfo.AuthUrl = testServer.BaseUrl;
+            var mockHttpClient = new HttpClient();
 
-            // Act
-            var result = await sut.AuthorizeAccountAync(dummyKeyId, dummyApplicationKey, CancellationToken.None);
+            var clientOptions = new ClientOptions();
 
-            // Assert
-            result.IsSuccessStatusCode.Should().BeTrue();
-            result.Response.Should().NotBeNull();
-            result.Response.Allowed.Should().NotBeNull();
-            result.Response.Allowed.Capabilities.Should().BeEquivalentTo(dummyCapabilities);
-            result.Response.Allowed.UnknownCapabilities.Should().BeEmpty();
-        }
-    }
+            clientOptions.RequestMaxParallel = 1;
+            clientOptions.DownloadMaxParallel = 1;
+            clientOptions.UploadMaxParallel = 1;
+            clientOptions.TestMode = "";
 
-    [Fact]
-    public async Task AuthorizeAccountAync_should_parse_unknown_capabilities()
-    {
-        // Arrange
-        var faker = new Faker();
+            var mockLogger = Substitute.For<ILogger<ApiRest>>();
 
-        var dummyKeyId = faker.Random.Hash();
-        var dummyApplicationKey = faker.Random.Hash();
-        var dummyAccountId = faker.Random.Hash();
-        var dummyAuthorizationToken = faker.Random.Hash();
-        var dummyApiUrl = new Uri(faker.Internet.Url());
-        var dummyDownloadUrl = new Uri(faker.Internet.Url());
-        var dummyCapabilities = faker.PickRandom(Enum.GetValues(typeof(Capability)).OfType<Capability>(), 5).ToList();
-        var dummyCapabilityStrings = dummyCapabilities.Select(c => c.ToString()).ToList();
+            var mockMemoryCache = Substitute.For<IMemoryCache>();
 
-        var unknownDummyCapabilities =
-            new[]
+            using (var testServer = new TestServer())
             {
-                "UnknownCapability1",
-                "UnknownCapability2",
-            };
+                testServer
+                    .When("/b2_authorize_account")
+                    .Then(
+                        new AuthorizeAccountResponseRaw()
+                        {
+                            AccountId = dummyAccountId,
+                            AuthorizationToken = dummyAuthorizationToken,
+                            ApiUrl = dummyApiUrl,
+                            DownloadUrl = dummyDownloadUrl,
+                            Allowed =
+                                new AllowedRaw()
+                                {
+                                    Capabilities = dummyCapabilityStrings
+                                }
+                        });
 
-        dummyCapabilityStrings.AddRange(unknownDummyCapabilities);
+                var sut = new ApiClient(mockHttpClient, clientOptions, mockLogger, mockMemoryCache);
 
-        var mockHttpClient = new HttpClient();
+                sut.AccountInfo.AuthUrl = testServer.BaseUrl;
 
-        var clientOptions = new ClientOptions();
+                // Act
+                var result = await sut.AuthorizeAccountAync(dummyKeyId, dummyApplicationKey, CancellationToken.None);
 
-        clientOptions.RequestMaxParallel = 1;
-        clientOptions.DownloadMaxParallel = 1;
-        clientOptions.UploadMaxParallel = 1;
-        clientOptions.TestMode = "";
+                // Assert
+                result.IsSuccessStatusCode.Should().BeTrue();
+                result.Response.Should().NotBeNull();
+                result.Response.Allowed.Should().NotBeNull();
+                result.Response.Allowed.Capabilities.Should().BeEquivalentTo(dummyCapabilities);
+                result.Response.Allowed.UnknownCapabilities.Should().BeEmpty();
+            }
+        }
 
-        var mockLogger = Substitute.For<ILogger<ApiRest>>();
-
-        var mockMemoryCache = Substitute.For<IMemoryCache>();
-
-        using (var testServer = new TestServer())
+        [Fact]
+        public async Task AuthorizeAccountAync_should_parse_unknown_capabilities()
         {
-            testServer
-                .When("/b2_authorize_account")
-                .Then(
-                    new AuthorizeAccountResponseRaw()
-                    {
-                        AccountId = dummyAccountId,
-                        AuthorizationToken = dummyAuthorizationToken,
-                        ApiUrl = dummyApiUrl,
-                        DownloadUrl = dummyDownloadUrl,
-                        Allowed =
-                            new AllowedRaw()
-                            {
-                                Capabilities = dummyCapabilityStrings
-                            }
-                    });
+            // Arrange
+            var faker = new Faker();
 
-            var sut = new ApiClient(mockHttpClient, clientOptions, mockLogger, mockMemoryCache);
+            var dummyKeyId = faker.Random.Hash();
+            var dummyApplicationKey = faker.Random.Hash();
+            var dummyAccountId = faker.Random.Hash();
+            var dummyAuthorizationToken = faker.Random.Hash();
+            var dummyApiUrl = new Uri(faker.Internet.Url());
+            var dummyDownloadUrl = new Uri(faker.Internet.Url());
+            var dummyCapabilities = faker.PickRandom(Enum.GetValues(typeof(Capability)).OfType<Capability>(), 5).ToList();
+            var dummyCapabilityStrings = dummyCapabilities.Select(c => c.ToString()).ToList();
 
-            sut.AccountInfo.AuthUrl = testServer.BaseUrl;
+            var unknownDummyCapabilities =
+                new[]
+                {
+                    "UnknownCapability1",
+                    "UnknownCapability2",
+                };
 
-            // Act
-            var result = await sut.AuthorizeAccountAync(dummyKeyId, dummyApplicationKey, CancellationToken.None);
+            dummyCapabilityStrings.AddRange(unknownDummyCapabilities);
 
-            // Assert
-            result.IsSuccessStatusCode.Should().BeTrue();
-            result.Response.Should().NotBeNull();
-            result.Response.Allowed.Should().NotBeNull();
-            result.Response.Allowed.Capabilities.Should().BeEquivalentTo(dummyCapabilities);
-            result.Response.Allowed.UnknownCapabilities.Should().BeEquivalentTo(unknownDummyCapabilities);
+            var mockHttpClient = new HttpClient();
+
+            var clientOptions = new ClientOptions();
+
+            clientOptions.RequestMaxParallel = 1;
+            clientOptions.DownloadMaxParallel = 1;
+            clientOptions.UploadMaxParallel = 1;
+            clientOptions.TestMode = "";
+
+            var mockLogger = Substitute.For<ILogger<ApiRest>>();
+
+            var mockMemoryCache = Substitute.For<IMemoryCache>();
+
+            using (var testServer = new TestServer())
+            {
+                testServer
+                    .When("/b2_authorize_account")
+                    .Then(
+                        new AuthorizeAccountResponseRaw()
+                        {
+                            AccountId = dummyAccountId,
+                            AuthorizationToken = dummyAuthorizationToken,
+                            ApiUrl = dummyApiUrl,
+                            DownloadUrl = dummyDownloadUrl,
+                            Allowed =
+                                new AllowedRaw()
+                                {
+                                    Capabilities = dummyCapabilityStrings
+                                }
+                        });
+
+                var sut = new ApiClient(mockHttpClient, clientOptions, mockLogger, mockMemoryCache);
+
+                sut.AccountInfo.AuthUrl = testServer.BaseUrl;
+
+                // Act
+                var result = await sut.AuthorizeAccountAync(dummyKeyId, dummyApplicationKey, CancellationToken.None);
+
+                // Assert
+                result.IsSuccessStatusCode.Should().BeTrue();
+                result.Response.Should().NotBeNull();
+                result.Response.Allowed.Should().NotBeNull();
+                result.Response.Allowed.Capabilities.Should().BeEquivalentTo(dummyCapabilities);
+                result.Response.Allowed.UnknownCapabilities.Should().BeEquivalentTo(unknownDummyCapabilities);
+            }
         }
     }
 }

--- a/test/Unit/ApiClientFixture.cs
+++ b/test/Unit/ApiClientFixture.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+
+using Bytewizer.Backblaze.Client;
+using Bytewizer.Backblaze.Client.Internal;
+
+using Xunit;
+
+using Bogus;
+
+using NSubstitute;
+
+using FluentAssertions;
+
+using Bytewizer.Backblaze.Models;
+
+public class ApiClientFixture
+{
+    [Fact]
+    public async Task AuthorizeAccountAync_should_parse_capabilities()
+    {
+        // Arrange
+        var faker = new Faker();
+
+        var dummyKeyId = faker.Random.Hash();
+        var dummyApplicationKey = faker.Random.Hash();
+        var dummyAccountId = faker.Random.Hash();
+        var dummyAuthorizationToken = faker.Random.Hash();
+        var dummyApiUrl = new Uri(faker.Internet.Url());
+        var dummyDownloadUrl = new Uri(faker.Internet.Url());
+        var dummyCapabilities = faker.PickRandom(Enum.GetValues(typeof(Capability)).OfType<Capability>(), 5).ToList();
+        var dummyCapabilityStrings = dummyCapabilities.Select(c => c.ToString()).ToList();
+
+        var mockHttpClient = new HttpClient();
+
+        var clientOptions = new ClientOptions();
+
+        clientOptions.RequestMaxParallel = 1;
+        clientOptions.DownloadMaxParallel = 1;
+        clientOptions.UploadMaxParallel = 1;
+        clientOptions.TestMode = "";
+
+        var mockLogger = Substitute.For<ILogger<ApiRest>>();
+
+        var mockMemoryCache = Substitute.For<IMemoryCache>();
+
+        using (var testServer = new TestServer())
+        {
+            testServer
+                .When("/b2_authorize_account")
+                .Then(
+                    new AuthorizeAccountResponseRaw()
+                    {
+                        AccountId = dummyAccountId,
+                        AuthorizationToken = dummyAuthorizationToken,
+                        ApiUrl = dummyApiUrl,
+                        DownloadUrl = dummyDownloadUrl,
+                        Allowed =
+                            new AllowedRaw()
+                            {
+                                Capabilities = dummyCapabilityStrings
+                            }
+                    });
+
+            var sut = new ApiClient(mockHttpClient, clientOptions, mockLogger, mockMemoryCache);
+
+            sut.AccountInfo.AuthUrl = testServer.BaseUrl;
+
+            // Act
+            var result = await sut.AuthorizeAccountAync(dummyKeyId, dummyApplicationKey, CancellationToken.None);
+
+            // Assert
+            result.IsSuccessStatusCode.Should().BeTrue();
+            result.Response.Should().NotBeNull();
+            result.Response.Allowed.Should().NotBeNull();
+            result.Response.Allowed.Capabilities.Should().BeEquivalentTo(dummyCapabilities);
+            result.Response.Allowed.UnknownCapabilities.Should().BeEmpty();
+        }
+    }
+
+    [Fact]
+    public async Task AuthorizeAccountAync_should_parse_unknown_capabilities()
+    {
+        // Arrange
+        var faker = new Faker();
+
+        var dummyKeyId = faker.Random.Hash();
+        var dummyApplicationKey = faker.Random.Hash();
+        var dummyAccountId = faker.Random.Hash();
+        var dummyAuthorizationToken = faker.Random.Hash();
+        var dummyApiUrl = new Uri(faker.Internet.Url());
+        var dummyDownloadUrl = new Uri(faker.Internet.Url());
+        var dummyCapabilities = faker.PickRandom(Enum.GetValues(typeof(Capability)).OfType<Capability>(), 5).ToList();
+        var dummyCapabilityStrings = dummyCapabilities.Select(c => c.ToString()).ToList();
+
+        var unknownDummyCapabilities =
+            new[]
+            {
+                faker.Random.Words(3),
+                faker.Random.Words(3),
+            };
+
+        dummyCapabilityStrings.AddRange(unknownDummyCapabilities);
+
+        var mockHttpClient = new HttpClient();
+
+        var clientOptions = new ClientOptions();
+
+        clientOptions.RequestMaxParallel = 1;
+        clientOptions.DownloadMaxParallel = 1;
+        clientOptions.UploadMaxParallel = 1;
+        clientOptions.TestMode = "";
+
+        var mockLogger = Substitute.For<ILogger<ApiRest>>();
+
+        var mockMemoryCache = Substitute.For<IMemoryCache>();
+
+        using (var testServer = new TestServer())
+        {
+            testServer
+                .When("/b2_authorize_account")
+                .Then(
+                    new AuthorizeAccountResponseRaw()
+                    {
+                        AccountId = dummyAccountId,
+                        AuthorizationToken = dummyAuthorizationToken,
+                        ApiUrl = dummyApiUrl,
+                        DownloadUrl = dummyDownloadUrl,
+                        Allowed =
+                            new AllowedRaw()
+                            {
+                                Capabilities = dummyCapabilityStrings
+                            }
+                    });
+
+            var sut = new ApiClient(mockHttpClient, clientOptions, mockLogger, mockMemoryCache);
+
+            sut.AccountInfo.AuthUrl = testServer.BaseUrl;
+
+            // Act
+            var result = await sut.AuthorizeAccountAync(dummyKeyId, dummyApplicationKey, CancellationToken.None);
+
+            // Assert
+            result.IsSuccessStatusCode.Should().BeTrue();
+            result.Response.Should().NotBeNull();
+            result.Response.Allowed.Should().NotBeNull();
+            result.Response.Allowed.Capabilities.Should().BeEquivalentTo(dummyCapabilities);
+            result.Response.Allowed.UnknownCapabilities.Should().BeEquivalentTo(unknownDummyCapabilities);
+        }
+    }
+}

--- a/test/Unit/ApiClientFixture.cs
+++ b/test/Unit/ApiClientFixture.cs
@@ -102,8 +102,8 @@ public class ApiClientFixture
         var unknownDummyCapabilities =
             new[]
             {
-                faker.Random.Words(3),
-                faker.Random.Words(3),
+                "UnknownCapability1",
+                "UnknownCapability2",
             };
 
         dummyCapabilityStrings.AddRange(unknownDummyCapabilities);

--- a/test/Unit/Backblaze.Tests.Unit.csproj
+++ b/test/Unit/Backblaze.Tests.Unit.csproj
@@ -25,7 +25,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Bogus" Version="35.6.1" />
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Unit/TestServer.cs
+++ b/test/Unit/TestServer.cs
@@ -9,69 +9,72 @@ using Microsoft.AspNetCore.Http;
 
 using Microsoft.Extensions.Hosting;
 
-class TestServer : IDisposable
+namespace Backblaze.Tests.Unit
 {
-    WebApplication _application;
-
-    public WebApplication Application => _application;
-
-    public Uri BaseUrl => new Uri(_application.Urls.First());
-
-    public TestServer()
+    class TestServer : IDisposable
     {
-        var builder = WebApplication.CreateBuilder();
+        WebApplication _application;
 
-        _application = builder.Build();
+        public WebApplication Application => _application;
 
-        // Without this route on the root, routes on subpaths seem to always return 404.
-        _application.MapGet("/", () => "Test server");
+        public Uri BaseUrl => new Uri(_application.Urls.First());
 
-        var lifetime = (IHostApplicationLifetime)_application.Services.GetService(typeof(IHostApplicationLifetime));
-
-        var started = new ManualResetEvent(initialState: false);
-
-        lifetime.ApplicationStarted.Register(() => started.Set());
-
-        Task.Run(() => _application.Run());
-
-        started.WaitOne();
-    }
-
-    public RouteBuilder When(string route) => When(HttpMethod.Get, route);
-    public RouteBuilder When(HttpMethod method, string route) => new RouteBuilder(this, method, route);
-
-    public class RouteBuilder
-    {
-        TestServer _server;
-        HttpMethod _method;
-        string _route;
-
-        public RouteBuilder(TestServer server, HttpMethod method, string route)
+        public TestServer()
         {
-            _server = server;
-            _method = method;
-            _route = route;
+            var builder = WebApplication.CreateBuilder();
+
+            _application = builder.Build();
+
+            // Without this route on the root, routes on subpaths seem to always return 404.
+            _application.MapGet("/", () => "Test server");
+
+            var lifetime = (IHostApplicationLifetime)_application.Services.GetService(typeof(IHostApplicationLifetime));
+
+            var started = new ManualResetEvent(initialState: false);
+
+            lifetime.ApplicationStarted.Register(() => started.Set());
+
+            Task.Run(() => _application.Run());
+
+            started.WaitOne();
         }
 
-        public void Then(object result)
-            => Then(() => Results.Json(result));
+        public RouteBuilder When(string route) => When(HttpMethod.Get, route);
+        public RouteBuilder When(HttpMethod method, string route) => new RouteBuilder(this, method, route);
 
-        public void Then(Delegate action)
+        public class RouteBuilder
         {
-            if (_method == HttpMethod.Get)
-                _server.Application.MapGet(_route, action);
-            else if (_method == HttpMethod.Post)
-                _server.Application.MapPost(_route, action);
-            else
-                throw new NotSupportedException("Not supported in TestServer: HTTP method " + _method);
+            TestServer _server;
+            HttpMethod _method;
+            string _route;
+
+            public RouteBuilder(TestServer server, HttpMethod method, string route)
+            {
+                _server = server;
+                _method = method;
+                _route = route;
+            }
+
+            public void Then(object result)
+                => Then(() => Results.Json(result));
+
+            public void Then(Delegate action)
+            {
+                if (_method == HttpMethod.Get)
+                    _server.Application.MapGet(_route, action);
+                else if (_method == HttpMethod.Post)
+                    _server.Application.MapPost(_route, action);
+                else
+                    throw new NotSupportedException("Not supported in TestServer: HTTP method " + _method);
+            }
         }
-    }
 
-    public void Dispose()
-    {
-        var task = _application.StopAsync();
+        public void Dispose()
+        {
+            var task = _application.StopAsync();
 
-        task.ConfigureAwait(false);
-        task.Wait();
+            task.ConfigureAwait(false);
+            task.Wait();
+        }
     }
 }

--- a/test/Unit/TestServer.cs
+++ b/test/Unit/TestServer.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+using Microsoft.Extensions.Hosting;
+
+class TestServer : IDisposable
+{
+    WebApplication _application;
+
+    public WebApplication Application => _application;
+
+    public Uri BaseUrl => new Uri(_application.Urls.First());
+
+    public TestServer()
+    {
+        var builder = WebApplication.CreateBuilder();
+
+        _application = builder.Build();
+
+        // Without this route on the root, routes on subpaths seem to always return 404.
+        _application.MapGet("/", () => "Test server");
+
+        var lifetime = (IHostApplicationLifetime)_application.Services.GetService(typeof(IHostApplicationLifetime));
+
+        var started = new ManualResetEvent(initialState: false);
+
+        lifetime.ApplicationStarted.Register(() => started.Set());
+
+        Task.Run(() => _application.Run());
+
+        started.WaitOne();
+    }
+
+    public RouteBuilder When(string route) => When(HttpMethod.Get, route);
+    public RouteBuilder When(HttpMethod method, string route) => new RouteBuilder(this, method, route);
+
+    public class RouteBuilder
+    {
+        TestServer _server;
+        HttpMethod _method;
+        string _route;
+
+        public RouteBuilder(TestServer server, HttpMethod method, string route)
+        {
+            _server = server;
+            _method = method;
+            _route = route;
+        }
+
+        public void Then(object result)
+            => Then(() => Results.Json(result));
+
+        public void Then(Delegate action)
+        {
+            if (_method == HttpMethod.Get)
+                _server.Application.MapGet(_route, action);
+            else if (_method == HttpMethod.Post)
+                _server.Application.MapPost(_route, action);
+            else
+                throw new NotSupportedException("Not supported in TestServer: HTTP method " + _method);
+        }
+    }
+
+    public void Dispose()
+    {
+        var task = _application.StopAsync();
+
+        task.ConfigureAwait(false);
+        task.Wait();
+    }
+}


### PR DESCRIPTION
Backblaze periodically adds new "capabilities" to the B2 API. The current strategy for parsing the models associated with successful logins requires all capabilities to be recognized. This breaks the library every time it happens. This PR aims to provide resiliency to this situation, by making the raw parsing of the "Allowed" structure in new type `AllowedRaw` just use a list of strings for the capabilities, and then later sorting them into known and unknown capabilities for the actual `Allowed` object returned by the `Connect` call.