### PR TITLE
fix: Allowed Capabilities with newly generated api keys

### DIFF
--- a/src/Client/Models/Enums/Capability.cs
+++ b/src/Client/Models/Enums/Capability.cs
@@ -140,5 +140,15 @@ namespace Bytewizer.Backblaze.Models
         /// Permission to write event notification rule information for a bucket.
         /// </summary>
         WriteBucketNotifications,
+
+        /// <summary>
+        /// Permission to read bucket logging information.
+        /// </summary>
+        ReadBucketLogging,
+
+        /// <summary>
+        /// Permission to write bucket logging information.
+        /// </summary>
+        WriteBucketLogging
     }
 }


### PR DESCRIPTION
This pull request introduces a small change to the `Capability` enum in `src/Client/Models/Enums/Capability.cs`. Two new capabilities related to bucket logging have been added.

* [`Capability.cs`](diffhunk://#diff-6457d1be1172ae663121f9b607bd2febf4200cfe8225949ff24156c9aa57a6b5R143-R152): Added `ReadBucketLogging` and `WriteBucketLogging` to represent permissions for reading and writing bucket logging information, respectively.